### PR TITLE
Expiration option for policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Or install it yourself as:
 ```ruby
 require 's3/authorize'
 
-s3_authorize = S3::Authorize.new(bucket: 'example', acl: 'public-read', 'secret_key': '356789032')
+s3_authorize = S3::Authorize.new(bucket: 'example', acl: 'public-read', secret_key: '356789032', expiration: 45) # expiration option (in minutes) is optional, it defaults to 60 minutes
 
 s3_policy = s3_authorize.policy # eyJleHBpcmF0aW9uIjoiMjAxNi0wNC0yNlQxOTozNjowNFoiLCJjb25 ....
 
-s3-signature = s3_authorize.signature(s3_policy) # VR9hEPY0zvMHOt ....
+s3_signature = s3_authorize.signature(s3_policy) # VR9hEPY0zvMHOt ....
 ```
 
 ## Contributing

--- a/lib/s3/authorize.rb
+++ b/lib/s3/authorize.rb
@@ -16,7 +16,7 @@ module S3
     #
     # Examples
     #
-    #   S3Authorize.new({bucket: 'example', acl: 'private', secret_key: '123456789'})
+    #   S3Authorize.new({bucket: 'example', acl: 'private', secret_key: '123456789', expiration: 60})
     #
     # Returns nothing
     def initialize(args)
@@ -24,6 +24,8 @@ module S3
       @bucket = args[:bucket]
       @acl = args[:acl]
       @secret_key = args[:secret_key]
+      calc_expiration = -> (minutes) { (Time.now + minutes * 60).utc.xmlschema }
+      @expiration = args[:expiration] ? calc_expiration.call(args[:expiration]) : calc_expiration.call(60)
     end
 
     # Generate policy
@@ -39,7 +41,7 @@ module S3
     def policy
       Base64.encode64(
         {
-          "expiration" => (Time.now + 60 * 60).utc.xmlschema,
+          "expiration" => @expiration,
           "conditions" => [
             { "bucket" => bucket },
             [ "starts-with", "$key", "" ],


### PR DESCRIPTION
Default behaviour changed to enable setting the expiration time (in minutes) for a policy.
