### PR TITLE
Allow custom content-length-range

### DIFF
--- a/lib/s3/authorize.rb
+++ b/lib/s3/authorize.rb
@@ -24,6 +24,8 @@ module S3
       @bucket = args[:bucket]
       @acl = args[:acl]
       @secret_key = args[:secret_key]
+      @min_file_size = args[:min_file_size] || 0
+      @max_file_size = args[:max_file_size] || (10 * 1024 * 1024)
     end
 
     # Generate policy
@@ -46,7 +48,7 @@ module S3
             { "acl" => acl },
             [ "starts-with", "$Content-Type", "" ],
             [ "starts-with", "$filename", "" ],
-            [ "content-length-range", 0, 10 * 1024 * 1024 ]
+            [ "content-length-range", @min_file_size, @max_file_size ]
           ]
         }.to_json).gsub(/\n/,'')
     end

--- a/lib/s3/authorize/version.rb
+++ b/lib/s3/authorize/version.rb
@@ -1,5 +1,5 @@
 module S3
   class Authorize
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
Not sure if you're still maintaining this, but just in case. I was running into an issue where my uploads larger than 10mb were failing. It took me a bit to realize the range was being set in this gem.

This PR adds the ability to customize the `content-length-range` header sent to s3. 

Optional arguments:  
`min_file_size`: Default is `0`
`max_file_size`: Default is `10485760` (what you previously had it)

No pressure to merge it in. Either way, thanks for making this!